### PR TITLE
Updated rust version to fix tower http related issue 

### DIFF
--- a/Dockerfile.discovery-handler
+++ b/Dockerfile.discovery-handler
@@ -1,5 +1,5 @@
-FROM amd64/rust:1.47 as build
-RUN rustup component add rustfmt --toolchain 1.47.0-x86_64-unknown-linux-gnu
+FROM amd64/rust:1.54 as build
+RUN rustup component add rustfmt --toolchain 1.54.0-x86_64-unknown-linux-gnu
 RUN USER=root cargo new --bin dh
 WORKDIR /dh
 COPY ./Cargo.toml ./Cargo.toml


### PR DESCRIPTION
I tried to build the docker image for the discovery handler and was facing the below error related to `tower-http` as shown in the screenshot. Later figured out that if we update the rust version to 1.54 it fixes the issue. Have created the PR for the same.

![image](https://user-images.githubusercontent.com/6823168/133207136-db73b6c7-b18b-42e1-a9dc-b938bff48377.png)


